### PR TITLE
Customization for Lova's Configuration

### DIFF
--- a/hosts/mainland.nix
+++ b/hosts/mainland.nix
@@ -102,7 +102,7 @@
 
   nix.settings = {
     download-buffer-size = 500000000; # 500 MB
-    trusted-users = ["root" "lova" "@wheel" "@trusted"];
+    trusted-users = ["lova" "@wheel" "@trusted"];
     experimental-features = ["flakes" "nix-command"];
     auto-optimise-store = true;
     # allow-import-from-derivation = false;

--- a/hosts/mainland.nix
+++ b/hosts/mainland.nix
@@ -99,4 +99,12 @@
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 
   # nix.settings.sandbox = false;
+
+  nix.settings = {
+    download-buffer-size = 500000000; # 500 MB
+    trusted-users = ["root" "lova" "@wheel" "@trusted"];
+    experimental-features = ["flakes" "nix-command"];
+    auto-optimise-store = true;
+    # allow-import-from-derivation = false;
+  };
 }

--- a/software/system/locale-eu-en-madagascar.nix
+++ b/software/system/locale-eu-en-madagascar.nix
@@ -5,7 +5,7 @@
 }: {
   # Set your time zone.
   # See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-  time.timeZone = "Europe/Lisbon";
+  time.timeZone = "Indian/Antananarivo";
 
   # Select internationalisation properties.
   i18n.defaultLocale = "en_GB.UTF-8";


### PR DESCRIPTION
- Switch Madagascar timezone to Indian/Antananarivo
- Customize `nix.settings` for `mainland.nix` to add username to trusted users and other tweaks

Hi @timlinux, I think we can customize the `nix.settings` in our specific host configuration and keep the `base.nix` to not compromise others configuration. Also, we don't need to add "root" to the `trusted-users` as it will be automatically added.